### PR TITLE
Feature/debugtokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -269,3 +269,4 @@ __pycache__/
 
 # secrets
 secrets.json
+debugsecrets.json

--- a/dbot/dbot/TokenManager.cs
+++ b/dbot/dbot/TokenManager.cs
@@ -15,7 +15,11 @@ namespace dbot
     {
         private static readonly string _discordToken = "discordToken";
         private static readonly string _omdbToken = "omdbToken";
+    #if DEBUG
+        private static readonly string _secretsUri = "debugsecrets.json";
+    #else
         private static readonly string _secretsUri = "secrets.json";
+    #endif
         
         public static string getToken(TokenKey tok)
         {


### PR DESCRIPTION
Added debug tokens so that development can happen without clobbering the production bot.


Note:

To run bot as debug
dotnet run
or
dotnet run -c Debug

To run bot as release
 dotnet run -c Release
