### PR TITLE
Bugfix/multiple nominations

### DIFF
--- a/dbot/dbot/CommandModules/NominationsModule.cs
+++ b/dbot/dbot/CommandModules/NominationsModule.cs
@@ -36,14 +36,22 @@ namespace dbot.CommandModules
                     Console.WriteLine($"Failed to find nominated movie \"{name}\"");
                     await ReplyAsync("Could not find this movie.");
                 }
-                else
+                else 
                 {
-                    Console.WriteLine($"Adding nominated movie \"{name}\"");
-                    await ReplyAsync(movie.ToString());
+                    if(!_nominationsService.IsNominated(movie.imdbID))
+                    {
+                        Console.WriteLine($"Adding nominated movie \"{name}\"");
+                        await ReplyAsync(movie.ToString());
 
-                    //if this isnt the right one, specify the year and change the nomination
-                    _nominationsService.AddNomination(Context.User, movie.Title, movie.imdbID);
-                    await ReplyAsync("Thanks for nominating!");
+                        //if this isnt the right one, specify the year and change the nomination
+                        _nominationsService.AddNomination(Context.User, movie.Title, movie.imdbID);
+                        await ReplyAsync("Thanks for nominating!");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Attempted to nominate duplicate movie \"{name}\"");
+                        await ReplyAsync($"{movie.Title} is already nominated!");
+                    }
                 }
             }
             else
@@ -68,12 +76,20 @@ namespace dbot.CommandModules
                 }
                 else
                 {
-                    Console.WriteLine($"Adding nominated movie \"{name}\"");
-                    await ReplyAsync(movie.ToString());
+                    if(!_nominationsService.IsNominated(movie.imdbID))
+                    {
+                        Console.WriteLine($"Adding nominated movie \"{name}\"");
+                        await ReplyAsync(movie.ToString());
 
-                    //if this isnt the right one, specify the year and change the nomination obj
-                    _nominationsService.AddNomination(Context.User, movie.Title, movie.imdbID);
-                    await ReplyAsync("Thanks for nominating!");
+                        //if this isnt the right one, specify the year and change the nomination obj
+                        _nominationsService.AddNomination(Context.User, movie.Title, movie.imdbID);
+                        await ReplyAsync("Thanks for nominating!");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Attempted to nominate duplicate movie \"{name}\"");
+                        await ReplyAsync($"{movie.Title} is already nominated!");
+                    }
                 }
             }
             else
@@ -98,12 +114,20 @@ namespace dbot.CommandModules
                 }
                 else
                 {
-                    Console.WriteLine($"Adding nominated movie \"{mov.Title}\"");
-                    await ReplyAsync(mov.ToString());
+                    if(!_nominationsService.IsNominated(mov.imdbID))
+                    {
+                        Console.WriteLine($"Adding nominated movie \"{name}\"");
+                        await ReplyAsync(mov.ToString());
 
-                    //if this isnt the right one, specify the year and change the nomination
-                    _nominationsService.AddNomination(Context.User, mov.Title, mov.imdbID);
-                    await ReplyAsync("Thanks for nominating!");
+                        //if this isnt the right one, specify the year and change the nomination
+                        _nominationsService.AddNomination(Context.User, mov.Title, mov.imdbID);
+                        await ReplyAsync("Thanks for nominating!");
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Attempted to nominate duplicate movie \"{name}\"");
+                        await ReplyAsync($"{mov.Title} is already nominated!");
+                    }
                 }
             }
             else

--- a/dbot/dbot/CommandModules/NominationsModule.cs
+++ b/dbot/dbot/CommandModules/NominationsModule.cs
@@ -116,7 +116,7 @@ namespace dbot.CommandModules
                 {
                     if(!_nominationsService.IsNominated(mov.imdbID))
                     {
-                        Console.WriteLine($"Adding nominated movie \"{name}\"");
+                        Console.WriteLine($"Adding nominated movie \"{id}\"");
                         await ReplyAsync(mov.ToString());
 
                         //if this isnt the right one, specify the year and change the nomination
@@ -125,7 +125,7 @@ namespace dbot.CommandModules
                     }
                     else
                     {
-                        Console.WriteLine($"Attempted to nominate duplicate movie \"{name}\"");
+                        Console.WriteLine($"Attempted to nominate duplicate movie \"{id}\"");
                         await ReplyAsync($"{mov.Title} is already nominated!");
                     }
                 }

--- a/dbot/dbot/Services/NominationsService.cs
+++ b/dbot/dbot/Services/NominationsService.cs
@@ -23,6 +23,12 @@ namespace dbot.Services
                     });
         }
 
+        public bool IsNominated(string imdbId)
+        {
+            var nominations = getNominations();
+            return nominations.Where(n => n.imdb == imdbId).Any();
+        }
+
         public string viewNominations() {
             var current = getNominations();
             var movies = current.Select(x => x.movName);

--- a/dbot/dbot/Services/NominationsService.cs
+++ b/dbot/dbot/Services/NominationsService.cs
@@ -18,6 +18,7 @@ namespace dbot.Services
                 currNoms.AddOrUpdate(userName, newNom,
                     (k, v) =>
                     {
+                        v.imdb    = newNom.imdb;
                         v.movName = newNom.movName;
                         return v;
                     });


### PR DESCRIPTION
Check that a movie has not been nominated before adding it to the nominations service.

Also fix latent bug where imdb ids were not updated on updated nominations.

This led to the following sequence being able to nominate duplicates even with the previous change:

```
Alice: Nominates X with id 1
>Nomination is accepted
Bob: Nominates X with id 1
>Nomination is not accepted due to duplicate id
Alice: Changes nomination to Y with id 2
>Alices nomination changes movie name to Y but does not update id
Bob: Nominates Y with id 2
>Nomination is accepted
Bob; Nominates X with id 1
>Nomination still not accepted
```