### PR TITLE
Feature/serialized voting state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,5 +271,9 @@ __pycache__/
 secrets.json
 debugsecrets.json
 
+# default serialization files
+votes.xml
+noms.xml
+
 #vscode
 .vscode

--- a/dbot/dbot/CommandModules/ViewModule.cs
+++ b/dbot/dbot/CommandModules/ViewModule.cs
@@ -35,7 +35,8 @@ namespace dbot.CommandModules
             
             if (!noms.Any())
             {
-                return;
+               await ReplyAsync($"There are no current nominations");
+               return;
             }
 
             var sb = new StringBuilder();
@@ -78,7 +79,7 @@ namespace dbot.CommandModules
         public async Task ViewVoters()
         {
             Console.WriteLine("Got view voters request");
-            
+
             if(_votingService.VotingOpen())
             {
                 var voters = _votingService.GetVoters();

--- a/dbot/dbot/CommandModules/ViewModule.cs
+++ b/dbot/dbot/CommandModules/ViewModule.cs
@@ -54,16 +54,22 @@ namespace dbot.CommandModules
         public async Task ViewVotes()
         {
             Console.WriteLine("Got view votes request");
-
-            var votes = _votingService.GetResults(_nominationsService.GetNominations());
-            var sb = new StringBuilder();
-
-            foreach (var v in votes)
+            if (_votingService.VotingOpen())
             {
-                sb.AppendLine($"{v.Movie.VotingId}. {v.Movie.Name}: {v.Votes}");
-            }
+                var votes = _votingService.GetResults(_nominationsService.GetNominations());
+                var sb = new StringBuilder();
 
-            await ReplyAsync(sb.ToString());
+                foreach (var v in votes)
+                {
+                    sb.AppendLine($"{v.Movie.VotingId}. {v.Movie.Name}: {v.Votes}");
+                }
+
+                await ReplyAsync(sb.ToString());
+            }
+            else
+            {
+                await ReplyAsync($"There is no vote in progress");
+            }
 
         }
         [Command("Voters")]
@@ -72,17 +78,25 @@ namespace dbot.CommandModules
         public async Task ViewVoters()
         {
             Console.WriteLine("Got view voters request");
-            var voters = _votingService.GetVoters();
-
-            var sb = new StringBuilder();
-            sb.AppendLine("Current Voters:");
-
-            foreach (var u in voters)
+            
+            if(_votingService.VotingOpen())
             {
-                sb.AppendLine($"{u.Username}");
-            }
+                var voters = _votingService.GetVoters();
 
-            await ReplyAsync(sb.ToString());
+                var sb = new StringBuilder();
+                sb.AppendLine("Current Voters:");
+
+                foreach (var u in voters)
+                {
+                    sb.AppendLine($"{u.Username}");
+                }
+
+                await ReplyAsync(sb.ToString());
+            }
+            else
+            {
+                await ReplyAsync($"There is no vote in progress");
+            }
         }
 
     }

--- a/dbot/dbot/CommandModules/votingmodule.cs
+++ b/dbot/dbot/CommandModules/votingmodule.cs
@@ -60,10 +60,9 @@ namespace dbot.CommandModules
             if (_votingService.VotingOpen())
             {
                 Console.WriteLine("Ending voting session");
+                var results = _votingService.GetResults(_nominationsService.GetNominations());
                 _votingService.EndVote();
 
-                var results = _votingService.GetResults(_nominationsService.GetNominations());
-                _votingService.ClearResults();
                 _nominationsService.ClearNominations();
 
                 var sb = new StringBuilder();

--- a/dbot/dbot/Services/VotingService.cs
+++ b/dbot/dbot/Services/VotingService.cs
@@ -23,8 +23,8 @@ namespace dbot.Services
 
         public VotingService(IRepository<User, int> votes)
         {
-            _votingOpen = false;
             _votes = votes;
+            _votingOpen = votes.Any();
         }
 
         public void Vote(IUser user, int movieId)
@@ -44,11 +44,13 @@ namespace dbot.Services
 
         public void StartVote()
         {
+            _votes.Clear();
             _votingOpen = true;
         }
 
         public void EndVote()
         {
+            _votes.Clear();
             _votingOpen = false;
         }
 
@@ -91,11 +93,6 @@ namespace dbot.Services
         public IEnumerable<User> GetVoters()
         {
             return _votes.Keys;
-        }
-
-        public void ClearResults()
-        {
-            _votes.Clear();
         }
     }
 }


### PR DESCRIPTION
Background:
When a server hosting the bot goes down we correctly recover the voting data from the serialized xml file. But there is no logic to recover the active voting state. When this happens it can be fixed by reissuing a !vote start command

The Fix:
When the voting service is initialized with a repository of votes it checks if there are any votes. If there are then it sets the votingOpen flag to true. This will fix issue mentioned above, but a !vote start will still be required if the bot crashes and restarts before a vote is cast

Other Things:
- Did some small cleanup of the logic for clearing votes
- Added some checks and extra messages in the view module
-- View votes and voters now requires an open vote
-- View nominations will now send a message if there are no nominations instead of silently passing
- Excluded the default serialization file names from the .gitignore 